### PR TITLE
update to call call_hrdetect.R from sigTools_runthrough.R

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # CHANGELOG
+## 1.5.1 -2023-10-24
+Update to call call_hrdetect.R from sigTools_runthrough.R
 ## 1.5 -2023-10-18
 Finalized version ready to release
 ## 1.4 - 2022-07-26

--- a/HRDetect.wdl
+++ b/HRDetect.wdl
@@ -238,8 +238,7 @@ task hrdResults {
 		File snvVcfIndexFiltered
 		File lohSegFile
 		String modules = "sigtools/2.4.1 sigtools-data/1.0 sigtools-rscript/1.0"
-		String sigtoolrScript = "$SIGTOOLS_RSCRIPT_ROOT/sigTools_runthrough.R"
-		String callHrdetectScript = "$SIGTOOLS_RSCRIPT_ROOT/call_hrdetect.R"
+		String sigtoolrScript = "$SIGTOOLS_RSCRIPT_ROOT/scripts/sigTools_runthrough.R"
 		String SVrefSigs = "$SIGTOOLS_DATA_ROOT/RefSigv0_Rearr.tsv"
 		String SNVrefSigs = "$SIGTOOLS_DATA_ROOT/COSMIC_v1_SBS_GRCh38.txt"
 		String genomeVersion
@@ -260,7 +259,6 @@ task hrdResults {
 		snvVcfIndexFiltered: "filtered SNV .vcf.tbi (indexed)"
 		lohSegFile: "reformatted segmentation file"
 		sigtoolrScript: ".R script containing sigtools"
-		callHrdetectScript: "R script to call hrdectect script"
 		outputFileNamePrefix: "Name of sample matching the tumor sample in .vcf"		
 		modules: "Required environment modules"
 		genomeVersion: "version of genome, eg hg38"
@@ -274,7 +272,6 @@ task hrdResults {
 	command <<<
 		set -euo pipefail
 
-		Rscript ~{callHrdetectScript}
 		Rscript ~{sigtoolrScript} \
 			--sampleName ~{outputFileNamePrefix} \
 			--snvFile ~{snvVcfFiltered} \

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Parameter|Value|Default|Description
 `filterSNVs.threads`|Int|1|Requested CPU threads
 `filterSNVs.timeout`|Int|2|Hours before task timeout
 `hrdResults.modules`|String|"sigtools/2.4.1 sigtools-data/1.0 sigtools-rscript/1.0"|Required environment modules
-`hrdResults.sigtoolrScript`|String|"$SIGTOOLS_RSCRIPT_ROOT/sigTools_runthrough.R"|.R script containing sigtools
+`hrdResults.sigtoolrScript`|String|"$SIGTOOLS_RSCRIPT_ROOT/scripts/sigTools_runthrough.R"|.R script containing sigtools
 `hrdResults.SVrefSigs`|String|"$SIGTOOLS_DATA_ROOT/RefSigv0_Rearr.tsv"|reference signatures for SVs
 `hrdResults.SNVrefSigs`|String|"$SIGTOOLS_DATA_ROOT/COSMIC_v1_SBS_GRCh38.txt"|reference signatures for SNVs
 `hrdResults.sigtoolsBootstrap`|Int|200|Number of bootstraps for sigtools

--- a/sigTools_runthrough.R
+++ b/sigTools_runthrough.R
@@ -2,6 +2,10 @@
 
 library(optparse)
 
+# Calling call_hrdetect.R
+basedir <- paste(Sys.getenv(c("BASE_DIR")), sep='/')
+source(paste0(basedir, "/call_hrdetect.R"))
+
 option_list = list(
   make_option(c("-s", "--sampleName"), type="character", default=NULL, help="sample name", metavar="character"),
   make_option(c("-r", "--SVrefSigs"), type="character", default=NULL, help="structural variant reference signatures", metavar="character"),

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -64,7 +64,6 @@
             "HRDetect.filterSNVs.timeout": null,
             "HRDetect.hrdResults.modules": null,
             "HRDetect.hrdResults.sigtoolrScript": null,
-            "HRDetect.hrdResults.callHrdetectScript": null,
             "HRDetect.hrdResults.SVrefSigs": null,
             "HRDetect.hrdResults.SNVrefSigs":null,
             "HRDetect.hrdResults.sigtoolsBootstrap": null,


### PR DESCRIPTION
Updating repo, can't test yet, as the repo and the module depend on each other, this repo depends on sigtools-rscript module, which need rebuild to base on the repo after this update. 